### PR TITLE
improved message when dataset is missing

### DIFF
--- a/R/check_var_downloaded.R
+++ b/R/check_var_downloaded.R
@@ -19,8 +19,8 @@ check_var_downloaded <- function(variable, dataset) {
     stop(
       "variable(s) (", paste(missing_vars, collapse = ", "),
       ") not yet downloaded, use `download_dataset(dataset = \"", dataset,
-      "\", bio_variables = c(", 
-      paste0('"',missing_vars,'"', collapse = ", "), "))`"
+      "\", bio_variables = c(",
+      paste0('"', missing_vars, '"', collapse = ", "), "))`"
     )
   }
   return(TRUE)

--- a/R/check_var_downloaded.R
+++ b/R/check_var_downloaded.R
@@ -18,7 +18,7 @@ check_var_downloaded <- function(variable, dataset) {
     ]
     stop(
       "variable (", paste(missing_vars, collapse = ", "),
-      ") not yet downloaded, use `download_dataset()`"
+      ") not yet downloaded, use `download_dataset(\"", dataset, "\")`"
     )
   }
   return(TRUE)

--- a/R/check_var_downloaded.R
+++ b/R/check_var_downloaded.R
@@ -17,8 +17,10 @@ check_var_downloaded <- function(variable, dataset) {
       !variable %in% get_downloaded_datasets()[[dataset]]
     ]
     stop(
-      "variable (", paste(missing_vars, collapse = ", "),
-      ") not yet downloaded, use `download_dataset(\"", dataset, "\")`"
+      "variable(s) (", paste(missing_vars, collapse = ", "),
+      ") not yet downloaded, use `download_dataset(dataset = \"", dataset,
+      "\", bio_variables = c(", 
+      paste0('"',missing_vars,'"', collapse = ", "), "))`"
     )
   }
   return(TRUE)

--- a/tests/testthat/test_location_series.R
+++ b/tests/testthat/test_location_series.R
@@ -95,7 +95,7 @@ test_that("location_series", {
       bio_variables = c("bio01", "bio12"),
       dataset = "Krapp2021"
     ),
-    "variable \\(bio01, bio12\\) not yet downloaded"
+    regexp = "variable\\(s\\) \\(bio01, bio12\\) not yet downloaded"
   )
 
   # test if we use a dataframe missing some coordinates

--- a/tests/testthat/test_location_slice.R
+++ b/tests/testthat/test_location_slice.R
@@ -144,7 +144,7 @@ test_that("location_slice", {
       time_bp = locations$time_bp, bio_variables = c("bio01", "bio12"),
       dataset = "Krapp2021", nn_interpol = FALSE
     ),
-    "variable \\(bio01, bio12\\) not yet downloaded"
+    regexp = "variable\\(s\\) \\(bio01, bio12\\) not yet downloaded"
   )
 
   # now test a custom dataset

--- a/tests/testthat/test_region_series.R
+++ b/tests/testthat/test_region_series.R
@@ -74,7 +74,7 @@ test_that("region series", {
       bio_variables = c("bio01", "bio19"),
       dataset = "Krapp2021"
     ),
-    "^variable \\(bio01, bio19\\) not yet downloaded"
+    regexp = "variable\\(s\\) \\(bio01, bio19\\) not yet downloaded"
   )
 
   # if we try to use a file that does not exist


### PR DESCRIPTION
When trying to get variables for missing datasets (not yet downloaded), the `download_dataset` prompted the following message `"variable x not yet downloaded, use `download_dataset()".` 
The message is now more informative as it includes the complete snip of code to download the dataset of interest:
`"variable x not yet downloaded, use `download_dataset(y)"`