### PR TITLE
fix multi download issue worldclim

### DIFF
--- a/R/download_worldclim_future.R
+++ b/R/download_worldclim_future.R
@@ -43,12 +43,37 @@ download_worldclim_future <- function(dataset, bio_var, filename = NULL) {
 
   # and now download the files (so the url is actually a local file)
   worldclim_url <- file.path(worldclim_dir, basename(download_url))
-  download_res <- curl::multi_download(download_url,
-    destfiles = worldclim_url
-  )
+  # extract the resolution from the dataset name 
+  resolution <- sub(".*_(\\d+\\.?\\d*)m$", "\\1", dataset)
+  
+  if (as.numeric(resolution) > 5){
+    download_res <- curl::multi_download(download_url,
+                                         destfiles = worldclim_url
+    )
+  } else {
+    # create a list to store the results 
+    download_res <- data.frame(
+      url = character(length(download_url)),
+      success = logical(length(download_url))
+    )
+    
+    
+    for (i in seq_along(download_url)){
+      download_res$url[i] <- curl::curl_download(download_url[i],
+                                          destfile = worldclim_url[i],
+                                          quiet = FALSE
+      )
+      download_res$success[i]<- file.exists(worldclim_url[i])
+    }
+  }
+  
+  # download_res <- curl::multi_download(download_url,
+  #    destfiles = worldclim_url
+  #  )
+  
   if (any(!download_res$success)) {
-    print(download_res[!download_res$success,])
-    stop("something went wrong downloading the data; try again")
+     print(download_res[!download_res$success,])
+     stop("something went wrong downloading the data; try again")
   }
 
 

--- a/R/download_worldclim_future.R
+++ b/R/download_worldclim_future.R
@@ -43,34 +43,34 @@ download_worldclim_future <- function(dataset, bio_var, filename = NULL) {
 
   # and now download the files (so the url is actually a local file)
   worldclim_url <- file.path(worldclim_dir, basename(download_url))
-  # extract the resolution from the dataset name 
+  # extract the resolution from the dataset name
   resolution <- sub(".*_(\\d+\\.?\\d*)m$", "\\1", dataset)
-  
-  if (as.numeric(resolution) > 5){
+
+  if (as.numeric(resolution) > 5) {
     download_res <- curl::multi_download(download_url,
-                                         destfiles = worldclim_url
+      destfiles = worldclim_url
     )
   } else {
-    # create a list to store the results 
+    # create a list to store the results
     download_res <- data.frame(
       url = character(length(download_url)),
       success = logical(length(download_url))
     )
-    
-    
-    for (i in seq_along(download_url)){
+
+
+    for (i in seq_along(download_url)) {
       download_res$url[i] <- curl::curl_download(download_url[i],
-                                          destfile = worldclim_url[i],
-                                          quiet = FALSE
+        destfile = worldclim_url[i],
+        quiet = FALSE
       )
-      download_res$success[i]<- file.exists(worldclim_url[i])
+      download_res$success[i] <- file.exists(worldclim_url[i])
     }
   }
-  
+  # nolint start
   # download_res <- curl::multi_download(download_url,
   #    destfiles = worldclim_url
   #  )
-  
+  # nolint end
   if (any(!download_res$success)) {
     print(download_res[!download_res$success, ])
     stop("something went wrong downloading the data; try again")

--- a/data-raw/notes_on_ecoregions.R
+++ b/data-raw/notes_on_ecoregions.R
@@ -1,4 +1,4 @@
-#path <- "/media/andrea/Elements/resolve2017/"
+# path <- "/media/andrea/Elements/resolve2017/"
 path <- normalizePath("~/project_temp/resolve2017/")
 # create the path if it does not exist
 if (!dir.exists(path)) {
@@ -22,8 +22,8 @@ worldclim_pres <- pastclim::region_slice(
   dataset = "WorldClim_2.1_10m"
 )
 ecoregions_rast <- terra::rast(terra::ext(worldclim_pres),
-                               resolution = terra::res(worldclim_pres),
-                               crs = terra::crs(worldclim_pres)
+  resolution = terra::res(worldclim_pres),
+  crs = terra::crs(worldclim_pres)
 )
 
 # rasterise the biomes at the resolutions of Worldclim
@@ -44,10 +44,10 @@ time(ecoregions_rast, "years") <- time(worldclim_pres)
 # now save this
 ncdf_filename <- file.path(path, "ecoregions_1985.nc")
 terra::writeCDF(ecoregions_rast,
-                varname = "biome",
-                longname = "biome from RESOLVE Ecoregions 2017",
-                filename = ncdf_filename, prec = "integer",
-                overwrite = TRUE
+  varname = "biome",
+  longname = "biome from RESOLVE Ecoregions 2017",
+  filename = ncdf_filename, prec = "integer",
+  overwrite = TRUE
 )
 # fix a few things in the netcdf file
 nc_in <- ncdf4::nc_open(ncdf_filename, write = TRUE)
@@ -58,8 +58,8 @@ format_line <- function(x) {
   paste0(paste(x, collapse = "  "), "; ")
 }
 ncdf4::ncatt_put(nc_in,
-                 varid = "biome", attname = "biomes",
-                 attval = paste(apply(ecoregions_meta[[1]], 1, format_line), collapse = "")
+  varid = "biome", attname = "biomes",
+  attval = paste(apply(ecoregions_meta[[1]], 1, format_line), collapse = "")
 )
 ncdf4::nc_close(nc_in)
 

--- a/tests/testthat/test_distance_from_sea.R
+++ b/tests/testthat/test_distance_from_sea.R
@@ -12,7 +12,6 @@ set_data_path(
 ################################################################################
 
 testthat::test_that("get biome classes", {
-
   distance_spatrast <- distance_from_sea(
     time_bp = -10000,
     dataset = "Example"


### PR DESCRIPTION
For future datasets with resolution higher than or equal to 5min, there seems to be a limit for multi-download. 
Implemented a way to use a simple single-file download.